### PR TITLE
Remove references to dummied out food

### DIFF
--- a/Youkai_Disco/youkai_item_groups.json
+++ b/Youkai_Disco/youkai_item_groups.json
@@ -166,10 +166,10 @@
       [ "sake_filtered", 50 ],
       [ "sake_unfiltered", 60 ],
       [ "brandy", 5 ],
-      [ "mannwurst", 20 ],
-      [ "sandwich_human", 30 ],
-      [ "human_haggis", 5 ],
-      [ "human_smoked", 40 ],
+      [ "sausage", 20 ],
+      [ "sandwich_t", 30 ],
+      [ "haggis", 5 ],
+      [ "meat_smoked", 40 ],
       [ "koji", 3 ]
     ]
   },


### PR DESCRIPTION
Sadly I don't yet see a way to flag items in an itemgroup as having the cannibalism setting, so this will have to do to avoid load errors.