### PR TITLE
Small syntax fix

### DIFF
--- a/Youkai_Disco/youkai_items.json
+++ b/Youkai_Disco/youkai_items.json
@@ -20,7 +20,7 @@
     "type": "COMESTIBLE",
     "id": "nekomata_tails",
     "symbol": "<",
-    "color": "dark_grey",
+    "color": "dark_gray",
     "name": "pair of nekomata tails",
     "name_plural": "pairs of nekomata tails",
     "material": "flesh",


### PR DESCRIPTION
Now that consistent color names are being enforced via load error, had to fix that. Just a single use of `dark_grey` instead of `dark_gray`, so it was easy enough.